### PR TITLE
Guard against nil :totalHours

### DIFF
--- a/src/time_off/helper.bb
+++ b/src/time_off/helper.bb
@@ -14,7 +14,7 @@
   weekday)
 
 (def is-already-booked? (fn [m d]
-                          (>= (get-in m [(keyword d) :totalHours]) 8)))
+                          (>= (or (get-in m [(keyword d) :totalHours]) 0) 8)))
 (defn partition-already-booked
   [current-timesheet dates]
   (rename-keys 


### PR DESCRIPTION
Prevent situations where :totalHours returns nil `(>= nil 8) => clojure.lang.ExceptionInfo: null`